### PR TITLE
VDFWriter & overloaded get() methods in VDFNode

### DIFF
--- a/src/main/java/net/platinumdigitalgroup/jvdf/VDFBinder.java
+++ b/src/main/java/net/platinumdigitalgroup/jvdf/VDFBinder.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
  */
 public class VDFBinder {
 
-    private VDFNode rootNode;
+    private final VDFNode rootNode;
 
     /**
      * Initializes the VDF binder with a VDF root node.
@@ -44,7 +44,7 @@ public class VDFBinder {
      * @param obj the POJO to bind the VDF node to
      */
     public void bindTo(Object obj) {
-        Class clazz = obj.getClass();
+        Class<?> clazz = obj.getClass();
         Field[] fields = clazz.getDeclaredFields();
 
         Arrays.stream(fields)
@@ -96,7 +96,7 @@ public class VDFBinder {
             throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 
         VDFNode node = rootNode.getSubNode(key);
-        Class type = f.getType();
+        Class<?> type = f.getType();
 
         Object newObj = createType(obj, type);
         new VDFBinder(node).bindTo(newObj);
@@ -104,12 +104,12 @@ public class VDFBinder {
         f.set(obj, newObj);
     }
 
-    private Object createType(Object parent, Class type)
+    private Object createType(Object parent, Class<?> type)
             throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 
         if(type.isMemberClass()) {
-            Class parentType = type.getDeclaringClass();
-            Constructor ctor = type.getDeclaredConstructor(parentType);
+            Class<?> parentType = type.getDeclaringClass();
+            Constructor<?> ctor = type.getDeclaredConstructor(parentType);
 
             if(ctor != null) {
                 return ctor.newInstance(parent);

--- a/src/main/java/net/platinumdigitalgroup/jvdf/VDFNode.java
+++ b/src/main/java/net/platinumdigitalgroup/jvdf/VDFNode.java
@@ -64,7 +64,19 @@ public class VDFNode extends TreeMap<String, Object[]> {
      * @return the string value of the specified key, or null if the key does not exist in this node
      */
     public String getString(String key, int index) {
-       return (String)this.get(key)[index];
+        Object[] objects = this.get(key);
+        return objects != null ? (String) objects[index] : null;
+    }
+
+    /**
+     * Fetches an String value by name.
+     * @param key the key name
+     * @param defaultValue the String value to return if the key does not exist in this node
+     * @return the String value of the specified key, or the default value if the key does not exist in this node
+     * */
+    public String getString(String key, String defaultValue) {
+        String value = getString(key, 0);
+        return value != null ? value : defaultValue;
     }
 
     /**
@@ -75,22 +87,45 @@ public class VDFNode extends TreeMap<String, Object[]> {
     public String getString(String key) {
         return getString(key, 0);
     }
+
     /**
      * Fetches an integer value by name.
      * @param key the key name
      * @return the int value of the specified key, or 0 if the key does not exist in this node
      */
     public int getInt(String key) {
-        return Integer.parseInt(getString(key));
+        return getInt(key, 0);
+    }
+
+    /**
+     * Fetches an integer value by name.
+     * @param key the key name
+     * @param defaultValue the int value to return if the key does not exist in this node
+     * @return the int value of the specified key, or the default value if the key does not exist in this node
+     * */
+    public int getInt(String key, int defaultValue) {
+        String value = getString(key);
+        return value != null ? Integer.parseInt(value) : defaultValue;
     }
 
     /**
      * Fetches a float value by name.
      * @param key the key name
-     * @return the float value of the specified key, or 0.f if the key does not exist in this node
+     * @return the float value of the specified key, or 0 if the key does not exist in this node
      */
     public float getFloat(String key) {
-        return Float.parseFloat(getString(key));
+        return getFloat(key, 0);
+    }
+
+    /**
+     * Fetches a float value by name.
+     * @param key the key name
+     * @param defaultValue the float value to return if the key does not exist in this node
+     * @return the float value of the specified key, or the default value if the key does not exist in this node
+     */
+    public float getFloat(String key, float defaultValue) {
+        String value = getString(key);
+        return value != null ? Float.parseFloat(value) : defaultValue;
     }
 
     /**
@@ -99,7 +134,18 @@ public class VDFNode extends TreeMap<String, Object[]> {
      * @return the long value of the specified key, or 0 if the key does not exist in this node
      */
     public long getLong(String key) {
-        return Long.parseLong(getString(key));
+        return getLong(key, 0);
+    }
+
+    /**
+     * Fetches a long value by name.
+     * @param key the key name
+     * @param defaultValue the long value to return if the key does not exist in this node
+     * @return the long value of the specified key, or the default value if the key does not exist in this node
+     */
+    public long getLong(String key, long defaultValue) {
+        String value = getString(key);
+        return value != null ? Long.parseLong(value) : defaultValue;
     }
 
     /**
@@ -127,6 +173,11 @@ public class VDFNode extends TreeMap<String, Object[]> {
      */
     public Color getColor(String key) {
         return Color.getColor(getString(key));
+    }
+
+    public Color getColor(String key, Color defaultValue) {
+        String value = getString(key);
+        return value != null ? Color.getColor(value) : defaultValue;
     }
 
     /**

--- a/src/main/java/net/platinumdigitalgroup/jvdf/VDFParser.java
+++ b/src/main/java/net/platinumdigitalgroup/jvdf/VDFParser.java
@@ -22,7 +22,7 @@ package net.platinumdigitalgroup.jvdf;
  */
 public class VDFParser {
 
-    private VDFPreprocessor preprocessor;
+    private final VDFPreprocessor preprocessor;
 
     /**
      * Initializes the VDFParser with a specific preprocessor

--- a/src/main/java/net/platinumdigitalgroup/jvdf/VDFParserState.java
+++ b/src/main/java/net/platinumdigitalgroup/jvdf/VDFParserState.java
@@ -27,7 +27,7 @@ public class VDFParserState {
     /**
      * The root node is the base of the VDF document.  All subnodes are children of the root node.
      */
-    private VDFNode rootNode;
+    private final VDFNode rootNode;
 
     /**
      * Since a VDF document can have a virtually unlimited amount of subnodes, we use a stack datastructure to represent
@@ -35,7 +35,7 @@ public class VDFParserState {
      * top of the stack.  As we leave subnodes, the stack is popped.  The bottom of the stack should always point to
      * the root node.
      */
-    private Stack<VDFNode> childStack = new Stack<>();
+    private final Stack<VDFNode> childStack = new Stack<>();
 
     /**
      * This flag represents if the parser is currently iterating over a character preceded with an open quote. Since
@@ -67,7 +67,7 @@ public class VDFParserState {
     /**
      * General-use string buffer that represents the last token. This is cleared after every control character.
      */
-    private StringBuilder currentString = new StringBuilder();
+    private final StringBuilder currentString = new StringBuilder();
 
     /**
      * Initializes the parser state with a starting root node.

--- a/src/main/java/net/platinumdigitalgroup/jvdf/VDFWriter.java
+++ b/src/main/java/net/platinumdigitalgroup/jvdf/VDFWriter.java
@@ -1,0 +1,51 @@
+package net.platinumdigitalgroup.jvdf;
+
+import java.util.Map;
+import java.util.Set;
+
+public class VDFWriter {
+
+    public VDFWriter() {
+    }
+
+    public String write(VDFNode root) {
+        return write(root, new StringBuilder(), new StringBuilder());
+    }
+
+    private String write(VDFNode root, StringBuilder whitespace, StringBuilder builder) {
+        Set<Map.Entry<String, Object[]>> entries = root.entrySet();
+        for (Map.Entry<String, Object[]> entry : entries) {
+            String key = entry.getKey();
+            Object[] value = entry.getValue();
+            for (int i = 0; i < value.length; i++) {
+                builder.append(whitespace);
+                builder.append("\"").append(key).append("\"");
+                builder.append(" ");
+                Object obj = value[i];
+                if (!(obj instanceof VDFNode)) {
+                    builder.append("\"").append(obj).append("\"");
+                    if (i < value.length - 1) {
+                        builder.append("\n");
+                    }
+                }
+                else {
+                    VDFNode node = (VDFNode) obj;
+                    builder.append("{");
+                    if (!node.isEmpty()) {
+                        builder.append("\n");
+                        whitespace.append("    ");
+                    }
+                    builder.append(write(node, whitespace, new StringBuilder()));
+                    if (!node.isEmpty()) {
+                        whitespace.setLength(whitespace.length() - 4);
+                        builder.append(whitespace);
+                    }
+                    builder.append("}");
+                }
+            }
+            builder.append("\n");
+        }
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/net/platinumdigitalgroup/jvdf/VDFWriter.java
+++ b/src/main/java/net/platinumdigitalgroup/jvdf/VDFWriter.java
@@ -3,16 +3,24 @@ package net.platinumdigitalgroup.jvdf;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Writes multiple VDF nodes into a human readable String.
+ * @author AreteS0ftware
+ */
 public class VDFWriter {
 
     public VDFWriter() {
     }
 
     public String write(VDFNode root) {
-        return write(root, new StringBuilder(), new StringBuilder());
+        return write(root, false);
     }
 
-    private String write(VDFNode root, StringBuilder whitespace, StringBuilder builder) {
+    public String write(VDFNode root, boolean newLineOnNode) {
+        return write(root, new StringBuilder(), new StringBuilder(), newLineOnNode);
+    }
+
+    private String write(VDFNode root, StringBuilder whitespace, StringBuilder builder, boolean newLineOnNode) {
         Set<Map.Entry<String, Object[]>> entries = root.entrySet();
         for (Map.Entry<String, Object[]> entry : entries) {
             String key = entry.getKey();
@@ -30,12 +38,16 @@ public class VDFWriter {
                 }
                 else {
                     VDFNode node = (VDFNode) obj;
+                    if (newLineOnNode) {
+                        builder.append("\n");
+                        builder.append(whitespace);
+                    }
                     builder.append("{");
                     if (!node.isEmpty()) {
                         builder.append("\n");
                         whitespace.append("    ");
                     }
-                    builder.append(write(node, whitespace, new StringBuilder()));
+                    write(node, whitespace, builder, newLineOnNode);
                     if (!node.isEmpty()) {
                         whitespace.setLength(whitespace.length() - 4);
                         builder.append(whitespace);

--- a/src/test/java/net/platinumdigitalgroup/jvdf/TestParser.java
+++ b/src/test/java/net/platinumdigitalgroup/jvdf/TestParser.java
@@ -3,6 +3,7 @@ package net.platinumdigitalgroup.jvdf;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.awt.Color;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -140,6 +141,21 @@ public class TestParser {
                 .getSubNode("second_sub_node")
                 .getSubNode("third_sub_node")
                 .getString("fourth"));
+    }
+
+    @Test
+    public void testDefaultValue() {
+        VDFNode root = parser.parse(VDF_SAMPLE);
+        Assert.assertEquals("not_existing", root
+                .getString("this_key_does_not_exist", "not_existing"));
+        Assert.assertEquals(1, root
+                .getInt("this_key_does_not_exist", 1));
+        Assert.assertEquals(0.123f, root
+                .getFloat("this_key_does_not_exist", 0.123f), 0f);
+        Assert.assertEquals(Long.MAX_VALUE, root
+                .getLong("this_key_does_not_exist", Long.MAX_VALUE), 0f);
+        Assert.assertEquals(Color.CYAN, root
+                .getColor("this_key_does_not_exist", Color.CYAN));
     }
 
     @Test

--- a/src/test/java/net/platinumdigitalgroup/jvdf/TestWriter.java
+++ b/src/test/java/net/platinumdigitalgroup/jvdf/TestWriter.java
@@ -42,41 +42,49 @@ public class TestWriter {
             "    }\n" +
             "}";
 
-    private static final String test = "\"keyvalues\"\n " +
-            "{\n" +
-            "    \"Material\" {\n" +
-            "        \"MaterialData\" {\n" +
-            "            \"Vertices\" {\n" +
-            "                \"Color\" {\n" +
-            "                    \"vertex\" \"0.92156863 0.03529412 0.03529412 1.0\"\n" +
-            "                    \"vertex\" \"0.2 0.0 1.0 1.0\"\n" +
-            "                    \"vertex\" \"0.05490196 1.0 0.039215688 1.0\"\n" +
-            "                    \"vertex\" \"0.9490196 0.9490196 0.047058824 1.0\"\n" +
-            "                    \"vertex\" \"0.92156863 0.10980392 0.8392157 1.0\"\n" +
-            "                    \"vertex\" \"1.0 1.0 1.0 1.0\"\n" +
-            "                }\n" +
-            "                \"Position\" {\n" +
-            "                    \"vertex\" \"-3.99 -2.99\"\n" +
-            "                    \"vertex\" \"-2.99 2.01\"\n" +
-            "                    \"vertex\" \"1.01 0.01\"\n" +
-            "                    \"vertex\" \"3.01 -1.99\"\n" +
-            "                    \"vertex\" \"2.01 -4.99\"\n" +
-            "                    \"vertex\" \"-1.8385 -6.1870003\"\n" +
-            "                }\n" +
-            "            }\n" +
-            "            \"offset\" \"1.0 1.0\"\n" +
-            "        }\n" +
-            "        \"filePath\" \"/home/arete/Badlogic.jpg\"\n" +
-            "        \"ppm\" \"100.0\"\n" +
-            "        \"uWrap\" \"Repeat\"\n" +
-            "        \"vWrap\" \"MirroredRepeat\"\n" +
-            "    }\n" +
-            "}";
-
     @Test
     public void testSample() {
-        VDFNode node = parser.parse(test);
-        String result = writer.write(node);
-        Assert.assertEquals(test, result);
+        VDFNode node1 = parser.parse(VDF_SAMPLE);
+        String result = writer.write(node1, true);
+        VDFNode node2 = parser.parse(result);
+        //assertStringEquals(VDF_SAMPLE, result);
+        assertNodesEquals(node1, node2);
     }
+
+    @Test
+    public void testSampleMultimap() {
+        VDFNode node1 = parser.parse(VDF_SAMPLE_MULTIMAP);
+        String result = writer.write(node1, true);
+        VDFNode node2 = parser.parse(result);
+        //assertStringEquals(VDF_SAMPLE_MULTIMAP, result);
+        assertNodesEquals(node1, node2);
+    }
+
+    /*
+    private void assertStringEquals(String string1, String string2) {
+        String[] split1 = string1.split("\n");
+        String[] split2 = string2.split("\n");
+        for (int i = 0; i < split1.length; i++) {
+            Assert.assertEquals(split1[i].replace(" ", ""), split2[i].replace(" ", ""));
+        }
+    }
+     */
+
+    private void assertNodesEquals(VDFNode node1, VDFNode node2) {
+        for (String key : node1.keySet()) {
+            Object[] node1values = node1.get(key);
+            Object[] node2values = node2.get(key);
+            for (int i = 0; i < node1values.length; i++) {
+                Object obj1 = node1values[i];
+                Object obj2 = node2values[i];
+                if (!(obj1 instanceof VDFNode) && !(obj2 instanceof VDFNode)) {
+                    Assert.assertEquals(obj1, obj2);
+                }
+                else {
+                    assertNodesEquals((VDFNode) obj1, (VDFNode) obj2);
+                }
+            }
+        }
+    }
+
 }

--- a/src/test/java/net/platinumdigitalgroup/jvdf/TestWriter.java
+++ b/src/test/java/net/platinumdigitalgroup/jvdf/TestWriter.java
@@ -1,0 +1,82 @@
+package net.platinumdigitalgroup.jvdf;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author AreteS0ftware
+ */
+public class TestWriter {
+
+    private final VDFParser parser = new VDFParser();
+    private final VDFWriter writer = new VDFWriter();
+
+    // Maven surefire bug can't include resources when forking is disabled
+    private static final String VDF_SAMPLE = "\"root_node\"\n" +
+            "{\n" +
+            "    \"first_sub_node\"\n" +
+            "    {\n" +
+            "        \"first\"     \"value1\"\n" +
+            "        \"second\"    \"value2\"\n" +
+            "    }\n" +
+            "    \"second_sub_node\"\n" +
+            "    {\n" +
+            "        \"third_sub_node\"\n" +
+            "        {\n" +
+            "            \"fourth\"    \"value4\"\n" +
+            "        }\n" +
+            "        \"third\"     \"value3\"\n" +
+            "    }\n" +
+            "}";
+    private static final String VDF_SAMPLE_MULTIMAP = "\"root_node\"\n" +
+            "{\n" +
+            "    \"sub_node\"\n" +
+            "    {\n" +
+            "        \"key\"       \"value1\"\n" +
+            "        \"key\"       \"value2\"\n" +
+            "    }\n" +
+            "    \"sub_node\"\n" +
+            "    {\n" +
+            "        \"key\"       \"value3\"\n" +
+            "        \"key\"       \"value4\"\n" +
+            "    }\n" +
+            "}";
+
+    private static final String test = "\"keyvalues\"\n " +
+            "{\n" +
+            "    \"Material\" {\n" +
+            "        \"MaterialData\" {\n" +
+            "            \"Vertices\" {\n" +
+            "                \"Color\" {\n" +
+            "                    \"vertex\" \"0.92156863 0.03529412 0.03529412 1.0\"\n" +
+            "                    \"vertex\" \"0.2 0.0 1.0 1.0\"\n" +
+            "                    \"vertex\" \"0.05490196 1.0 0.039215688 1.0\"\n" +
+            "                    \"vertex\" \"0.9490196 0.9490196 0.047058824 1.0\"\n" +
+            "                    \"vertex\" \"0.92156863 0.10980392 0.8392157 1.0\"\n" +
+            "                    \"vertex\" \"1.0 1.0 1.0 1.0\"\n" +
+            "                }\n" +
+            "                \"Position\" {\n" +
+            "                    \"vertex\" \"-3.99 -2.99\"\n" +
+            "                    \"vertex\" \"-2.99 2.01\"\n" +
+            "                    \"vertex\" \"1.01 0.01\"\n" +
+            "                    \"vertex\" \"3.01 -1.99\"\n" +
+            "                    \"vertex\" \"2.01 -4.99\"\n" +
+            "                    \"vertex\" \"-1.8385 -6.1870003\"\n" +
+            "                }\n" +
+            "            }\n" +
+            "            \"offset\" \"1.0 1.0\"\n" +
+            "        }\n" +
+            "        \"filePath\" \"/home/arete/Badlogic.jpg\"\n" +
+            "        \"ppm\" \"100.0\"\n" +
+            "        \"uWrap\" \"Repeat\"\n" +
+            "        \"vWrap\" \"MirroredRepeat\"\n" +
+            "    }\n" +
+            "}";
+
+    @Test
+    public void testSample() {
+        VDFNode node = parser.parse(test);
+        String result = writer.write(node);
+        Assert.assertEquals(test, result);
+    }
+}


### PR DESCRIPTION
Self-explanatory title. I already use this library in my game, but needed a few extra bells & whistles, so I may as well contribute.
Would've added `getBoolean()` but that's not compliant with the Value Types [here](https://developer.valvesoftware.com/wiki/KeyValues), so I didn't bother.

The unit tests for the VDFWriter are done that way because the output String is not a 1:1 copy of the input String, which makes `Assert.assertEquals()` fail - but it is functionally the same. If the output String is parsed, the resulting node is identical to the node one would obtain from parsing the Input string.

I also made most variables in VDFNode and other classes `final`, for good measure.